### PR TITLE
chore: builds docker from node 12.x LTS not 13.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # specify the node base image with your desired version node:<version>
-FROM node:13
+FROM node:12
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
Matches docs
