### PR TITLE
Fix for building examples

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "if [ -d .generated ]; then tsc; fi",
     "watch": "tsc -w",
     "lint": "eslint . --ext .ts",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "license": "Apache-2.0",
   "workspaces": {
     "packages": [
-      "examples/*",
       "packages/*",
-      "packages/@armkit/*"
+      "packages/@armkit/*",
+      "examples/*"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
This is an attempt at a lightweight fix for #42...

1. Build examples last
2. Only run `tsc` if the `.generated` directory is present


