### PR TITLE
Publish to NPM + GH

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,23 +1,40 @@
-name: Node.js Package
+name: Package and Publish
 on:
   release:
     types: [published]
 jobs:
-  build:
+  package_and_publish:
+    name: Package and Publish
     runs-on: ubuntu-latest 
     permissions: 
       contents: read
       packages: write 
     steps:
       - uses: actions/checkout@v2
+      - name: Package
+        run: |
+          yarn package        
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
           registry-url: 'https://npm.pkg.github.com'
-      - run: |
-          yarn package
-          cd packages/@armkit/core
+      - name: Publish to GitHub
+        run: |
           version=$(node -p 'require("./package.json").version')
-          yarn publish --registry=https://npm.pkg.github.com ./dist/js/armkit-core-${version}.tgz
+          yarn publish --registry=https://npm.pkg.github.com dist/js/yetics-armkit-core-${version}.tgz
+        working-directory: packages/@armkit/core
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Reset .npmrc
+        run: rm -f ${RUNNER_TEMP}/.npmrc
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Publish to NPM
+        run: |
+          version=$(node -p 'require("./package.json").version')
+          yarn publish --registry=https://registry.npmjs.org dist/js/yetics-armkit-core-${version}.tgz
+        working-directory: packages/@armkit/core
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This workflow should publish to both GitHub Packages and NPM.

For NPM, you need to generate an Access Token (type Automation) and set it in a secret called NPM_TOKEN on the repo.

For GHP, the token is generated automatically by GitHub.

To trigger the workflow, create a new release '0.0.0' with the corresponding tag, on the branch where the workflow is defined (i.e. main after merging this change). 