### PR TITLE
feature: remove Enum suffix from type names

### DIFF
--- a/packages/armkit-cli/lib/type-generator.ts
+++ b/packages/armkit-cli/lib/type-generator.ts
@@ -150,7 +150,7 @@ export class TypeGenerator {
           cleanTypeName = (parts[1] || '').substr('/definitions/'.length);
         }
         // console.log({ cleanTypeName })
-        return this.emitEnum(`${toPascalCase(cleanTypeName)}Enum`, def.enum)
+        return this.emitEnum(`${toPascalCase(cleanTypeName)}`, def.enum)
       }
 
       return 'string';
@@ -224,7 +224,7 @@ export class TypeGenerator {
             cleanTypeName = (parts[1] || '').substr('/definitions/'.length);
           }
 
-          type = this.emitEnum(`${cleanTypeName}Enum`, option.enum)
+          type = this.emitEnum(`${cleanTypeName}`, option.enum)
         } else if (!option.enum && option.type === 'array') {
           if (!option.items) type = 'any';
           const items = option.items as any


### PR DESCRIPTION
remove Enum suffix from type names as in `return this.emitEnum(`${toPascalCase(cleanTypeName)}Enum`, def.enum)` to `return this.emitEnum(`${toPascalCase(cleanTypeName)}`, def.enum)`