### PR TITLE
Fix for TypeError in emitUnion

### DIFF
--- a/packages/armkit-cli/lib/type-generator.ts
+++ b/packages/armkit-cli/lib/type-generator.ts
@@ -237,7 +237,8 @@ export class TypeGenerator {
             type = 'any'
           }
         } else if (option.properties) {
-          this.emitStruct(typeName, option, `${typeName}`)
+          type = typeName + def.oneOf?.indexOf(option)
+          this.emitStruct(type, option, `${type}`)
         } else if (Array.isArray(option.type) || option.required) {
           type = 'any'
         } else {


### PR DESCRIPTION
This is a proposed fix for #75, to be discussed as I am not sure how usable it is and/or if there is a better way!

This problem occurs for exemple here:

https://github.com/Azure/azure-resource-manager-schemas/blob/master/schemas/2020-11-01/Microsoft.Network.json#L10877

This is an object type, with a set of possible properties expressed using `oneOf`. In this case we need to give a name to the type, otherwise we trigger the TypeError (TypeError: Cannot read property 'toUpperCase' of undefined). We also need to give this type a *unique* name, however I could not find any discriminator I could use, so I decided to just use an index.

With this fix all the affected schemas can be generated without errors. However I am not sure how usable the result is. There might be a better way to express a union in TypeScript/JavaScript?

- https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types
- https://basarat.gitbook.io/typescript/type-system/discriminated-unions

Ping @aheumaier @ohthehugemanatee 