### PR TITLE
[WIP] Generate schemas with autorest

### DIFF
--- a/packages/generate-schemas/generate-schemas.sh
+++ b/packages/generate-schemas/generate-schemas.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+NPROC=8
+
+src=azure-rest-api-specs/specification
+dest=armkit-schemas
+
+# Clone the REST API spec repo
+
+git clone https://github.com/Azure/azure-rest-api-specs.git
+
+# Find all the readme.md file and pipe them to autorest
+# Run $NPROC jobs in parallel
+
+path="$src/*/resource-manager/readme.md"
+
+printf "%s\0" $path | xargs -0 -n 1 -P $NPROC autorest --azureresourceschema $i
+
+# Gather all generated schemas
+
+for i in $src/*/resource-manager/generated/[0-9]*
+do
+  d=$(basename $i)
+  mkdir -p $dest/$d
+  cp $i/*.json $dest/$d
+done

--- a/packages/generate-schemas/package-lock.json
+++ b/packages/generate-schemas/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "generate-schemas",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "autorest": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.2.0.tgz",
+      "integrity": "sha512-/hFBvyCxbfZ/xolqTGYRcIuyYWEDSRdxbPtcRKa0C/2td8W0IZLeDtDeX7f2fnCjPzd8WllGJhr8N49xL+AUiA=="
+    }
+  }
+}

--- a/packages/generate-schemas/package.json
+++ b/packages/generate-schemas/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "generate-schemas",
+  "version": "1.0.0",
+  "description": "Generate JSON Schemas from Azure REST API specs",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "generate": "bash generate-schemas.sh",
+    "clean": "rm -rf armkit-schemas && rm -rf azure-rest-api-specs"
+  },
+  "author": "Microsoft CSE",
+  "license": "MIT",
+  "dependencies": {
+    "autorest": "^3.2.0"
+  }
+}


### PR DESCRIPTION
Last week I started playing with Autorest to see how we could generate the JSON schemas ourselves instead of scraping them. This is what I got so far, a script that basically clones the REST API spec repo and then runs autorest on all the services to generate the schemas. The schemas are organised by version:

```
2021-05-01/Microsoft.Media.json
2021-02-01/Microsoft.Network.json
2019-06-01-preview/Microsoft.ContainerRegistry.json
```

Execute the script by running `yarn run generate`.

- The script currently only generates the latest version, I suppose it would be better to go back n versions.
- Once we have all the schemas we need, we could then generate the code based on these schemas.
